### PR TITLE
fix: tracking of initial beneficiary and delegatee

### DIFF
--- a/subgraph/src/uni-staker.ts
+++ b/subgraph/src/uni-staker.ts
@@ -46,12 +46,10 @@ export function handleBeneficiaryAltered(event: BeneficiaryAlteredEvent): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
-  const affacted = [deposit.owner, event.params.newBeneficiary]
   // Only tracking actual changes (beneficiary is initially set to address zero)
   if (event.params.oldBeneficiary.notEqual(Address.zero())) {
-    affacted.push(event.params.oldBeneficiary)
+    entity.affected = arrayUnique([deposit.owner, event.params.newBeneficiary, event.params.oldBeneficiary])
   }
-  entity.affected = arrayUnique(affacted)
   entity.save()
 }
 
@@ -71,12 +69,10 @@ export function handleDelegateeAltered(event: DelegateeAlteredEvent): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
-  const affacted = [deposit.owner, deposit.delegatee]
   // Only tracking actual changes (beneficiary is initially set to address zero)
   if (event.params.oldDelegatee.notEqual(Address.zero())) {
-    affacted.push(event.params.oldDelegatee)
+    entity.affected = arrayUnique([deposit.owner, deposit.delegatee, event.params.oldDelegatee])
   }
-  entity.affected = arrayUnique(affacted)
   entity.save()
 }
 

--- a/subgraph/src/uni-staker.ts
+++ b/subgraph/src/uni-staker.ts
@@ -46,10 +46,12 @@ export function handleBeneficiaryAltered(event: BeneficiaryAlteredEvent): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
+  let affected = new Array<Bytes>(0)
   // Only tracking actual changes (beneficiary is initially set to address zero)
   if (event.params.oldBeneficiary.notEqual(Address.zero())) {
-    entity.affected = arrayUnique([deposit.owner, event.params.newBeneficiary, event.params.oldBeneficiary])
+    affected = arrayUnique([deposit.owner, event.params.newBeneficiary, event.params.oldBeneficiary])
   }
+  entity.affected = affected
   entity.save()
 }
 
@@ -69,10 +71,12 @@ export function handleDelegateeAltered(event: DelegateeAlteredEvent): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
+  let affected = new Array<Bytes>(0)
   // Only tracking actual changes (beneficiary is initially set to address zero)
   if (event.params.oldDelegatee.notEqual(Address.zero())) {
-    entity.affected = arrayUnique([deposit.owner, deposit.delegatee, event.params.oldDelegatee])
+    affected = arrayUnique([deposit.owner, deposit.delegatee, event.params.oldDelegatee])
   }
+  entity.affected = affected
   entity.save()
 }
 

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -10,7 +10,7 @@ dataSources:
     source:
       address: "0xa3ad05099eab69055e4ea4f710361616e51c8c2c"
       abi: UniStaker
-      startBlock: 9971154c
+      startBlock: 9971154
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
Remove unwanted events for account.

Currently,  we show initial beneficiary and delegatee as changes separate events.
<img width="1147" alt="Screenshot 2024-04-04 at 14 49 18" src="https://github.com/avantgardefinance/UniStaking/assets/36133712/6bf4eb95-6ea4-4aef-9f90-f8374afff89d">
